### PR TITLE
New header version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "da-primitives"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "beefy-merkle-tree",
  "derive_more",

--- a/primitives/avail/Cargo.toml
+++ b/primitives/avail/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "da-primitives"
-version = "0.4.5"
+version = "0.4.6"
 authors = []
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 # Others

--- a/primitives/avail/src/header/extension/mod.rs
+++ b/primitives/avail/src/header/extension/mod.rs
@@ -8,6 +8,7 @@ use sp_core::{RuntimeDebug, H256};
 use sp_runtime_interface::pass_by::PassByCodec;
 
 pub mod v1;
+pub mod v2;
 
 #[cfg(feature = "header-backward-compatibility-test")]
 pub mod v_test;
@@ -17,6 +18,7 @@ pub mod v_test;
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub enum HeaderExtension {
 	V1(v1::HeaderExtension),
+	V2(v2::HeaderExtension),
 	#[cfg(feature = "header-backward-compatibility-test")]
 	VTest(v_test::HeaderExtension),
 }
@@ -27,6 +29,7 @@ macro_rules! forward_to_version {
 	($self:ident, $function:ident) => {{
 		match $self {
 			HeaderExtension::V1(header) => header.$function(),
+			HeaderExtension::V2(header) => header.$function(),
 			#[cfg(feature = "header-backward-compatibility-test")]
 			HeaderExtension::VTest(header) => header.$function(),
 		}
@@ -35,6 +38,7 @@ macro_rules! forward_to_version {
 	($self:ident, $function:ident, $arg:expr) => {{
 		match $self {
 			HeaderExtension::V1(header) => header.$function($arg),
+			HeaderExtension::V2(header) => header.$function($arg),
 			#[cfg(feature = "header-backward-compatibility-test")]
 			HeaderExtension::VTest(header) => header.$function($arg),
 		}
@@ -49,7 +53,7 @@ impl HeaderExtension {
 
 impl Default for HeaderExtension {
 	fn default() -> Self {
-		v1::HeaderExtension::default().into()
+		v2::HeaderExtension::default().into()
 	}
 }
 
@@ -64,6 +68,13 @@ impl From<v1::HeaderExtension> for HeaderExtension {
 	#[inline]
 	fn from(ext: v1::HeaderExtension) -> Self {
 		Self::V1(ext)
+	}
+}
+
+impl From<v2::HeaderExtension> for HeaderExtension {
+	#[inline]
+	fn from(ext: v2::HeaderExtension) -> Self {
+		Self::V2(ext)
 	}
 }
 

--- a/primitives/avail/src/header/extension/v2.rs
+++ b/primitives/avail/src/header/extension/v2.rs
@@ -6,7 +6,7 @@ use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
 use sp_core::{RuntimeDebug, H256};
 
-use crate::{asdr::DataLookup, v1::KateCommitment};
+use crate::{asdr::DataLookup, v2::KateCommitment};
 
 #[derive(PartialEq, Eq, Clone, RuntimeDebug, TypeInfo, Encode, Decode, Default)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
@@ -17,7 +17,7 @@ pub struct HeaderExtension {
 
 impl HeaderExtension {
 	pub fn data_root(&self) -> H256 {
-		self.commitment.data_root
+		self.commitment.data_root.unwrap_or_default()
 	}
 }
 

--- a/primitives/avail/src/header/mod.rs
+++ b/primitives/avail/src/header/mod.rs
@@ -258,7 +258,7 @@ mod tests {
 	use test_case::test_case;
 
 	use super::*;
-	use crate::kate_commitment::KateCommitment;
+	use crate::kate_commitment::{v1, v2};
 
 	#[test]
 	fn should_serialize_numbers() {
@@ -304,7 +304,7 @@ mod tests {
 
 	#[test]
 	fn ensure_format_is_unchanged() {
-		let commitment = KateCommitment {
+		let commitment = v1::KateCommitment {
 				rows: 1,
 				cols: 4,
 				data_root: hex!("3fbf3227926cfa3f4167771e5ad91cfa2c2d7090667ce01e911ca90b4f315b11").into(),
@@ -332,12 +332,29 @@ mod tests {
 	}
 
 	fn header_v1() -> Header<u32, BlakeTwo256> {
-		let commitment = KateCommitment {
+		let commitment = v1::KateCommitment {
 				commitment: hex!("80e949ebdaf5c13e09649c587c6b1905fb770b4a6843abaac6b413e3a7405d9825ac764db2341db9b7965965073e975980e949ebdaf5c13e09649c587c6b1905fb770b4a6843abaac6b413e3a7405d9825ac764db2341db9b7965965073e9759").to_vec(),
 				data_root: hex!("3fbf3227926cfa3f4167771e5ad91cfa2c2d7090667ce01e911ca90b4f315b11").into(),
 				..Default::default()
 			};
 		let extension = extension::v1::HeaderExtension {
+			commitment,
+			..Default::default()
+		};
+
+		Header::<u32, BlakeTwo256> {
+			extension: extension.into(),
+			..Default::default()
+		}
+	}
+
+	/// The `commitment.data_root is none`.
+	fn header_v2() -> Header<u32, BlakeTwo256> {
+		let commitment = v2::KateCommitment {
+				commitment: hex!("80e949ebdaf5c13e09649c587c6b1905fb770b4a6843abaac6b413e3a7405d9825ac764db2341db9b7965965073e975980e949ebdaf5c13e09649c587c6b1905fb770b4a6843abaac6b413e3a7405d9825ac764db2341db9b7965965073e9759").to_vec(),
+				..Default::default()
+			};
+		let extension = extension::v2::HeaderExtension {
 			commitment,
 			..Default::default()
 		};
@@ -366,6 +383,7 @@ mod tests {
 	}
 
 	#[test_case( header_v1().encode().as_ref() => Ok(header_v1()) ; "Decode V1 header")]
+	#[test_case( header_v2().encode().as_ref() => Ok(header_v2()) ; "Decode V2 header")]
 	#[test_case( header_test().encode().as_ref() => Ok(header_test()) ; "Decode test header")]
 	fn header_decoding(mut encoded_header: &[u8]) -> Result<Header<u32, BlakeTwo256>, Error> {
 		Header::decode(&mut encoded_header)

--- a/primitives/avail/src/kate_commitment.rs
+++ b/primitives/avail/src/kate_commitment.rs
@@ -5,30 +5,66 @@ use serde::{Deserialize, Serialize};
 use sp_core::H256;
 use sp_std::vec::Vec;
 
-/// Customized extrinsics root to save the commitment.
-#[derive(PartialEq, Eq, Clone, sp_core::RuntimeDebug, Default, Encode, Decode, TypeInfo)]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
-#[cfg_attr(feature = "std", serde(deny_unknown_fields))]
-pub struct KateCommitment {
-	/// Rows
-	#[codec(compact)]
-	pub rows: u16,
-	/// Cols
-	#[codec(compact)]
-	pub cols: u16,
-	/// The merkle root of the data submitted
-	pub data_root: H256,
-	/// Plonk commitment.
-	pub commitment: Vec<u8>,
+pub mod v1 {
+	use super::*;
+
+	/// Customized extrinsics root to save the commitment.
+	#[derive(PartialEq, Eq, Clone, sp_core::RuntimeDebug, Default, Encode, Decode, TypeInfo)]
+	#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+	#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
+	#[cfg_attr(feature = "std", serde(deny_unknown_fields))]
+	pub struct KateCommitment {
+		/// Rows
+		#[codec(compact)]
+		pub rows: u16,
+		/// Cols
+		#[codec(compact)]
+		pub cols: u16,
+		/// The merkle root of the data submitted
+		pub data_root: H256,
+		/// Plonk commitment.
+		pub commitment: Vec<u8>,
+	}
+
+	#[cfg(feature = "std")]
+	impl parity_util_mem::MallocSizeOf for KateCommitment {
+		fn size_of(&self, ops: &mut parity_util_mem::MallocSizeOfOps) -> usize {
+			self.commitment.size_of(ops)
+				+ self.rows.size_of(ops)
+				+ self.cols.size_of(ops)
+				+ self.data_root.size_of(ops)
+		}
+	}
 }
 
-#[cfg(feature = "std")]
-impl parity_util_mem::MallocSizeOf for KateCommitment {
-	fn size_of(&self, ops: &mut parity_util_mem::MallocSizeOfOps) -> usize {
-		self.commitment.size_of(ops)
-			+ self.rows.size_of(ops)
-			+ self.cols.size_of(ops)
-			+ self.data_root.size_of(ops)
+pub mod v2 {
+	use super::*;
+
+	/// Customized extrinsics root to save the commitment.
+	#[derive(PartialEq, Eq, Clone, sp_core::RuntimeDebug, Default, Encode, Decode, TypeInfo)]
+	#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+	#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
+	#[cfg_attr(feature = "std", serde(deny_unknown_fields))]
+	pub struct KateCommitment {
+		/// Rows
+		#[codec(compact)]
+		pub rows: u16,
+		/// Cols
+		#[codec(compact)]
+		pub cols: u16,
+		/// The merkle root of the data submitted
+		pub data_root: Option<H256>,
+		/// Plonk commitment.
+		pub commitment: Vec<u8>,
+	}
+
+	#[cfg(feature = "std")]
+	impl parity_util_mem::MallocSizeOf for KateCommitment {
+		fn size_of(&self, ops: &mut parity_util_mem::MallocSizeOfOps) -> usize {
+			self.commitment.size_of(ops)
+				+ self.rows.size_of(ops)
+				+ self.cols.size_of(ops)
+				+ self.data_root.size_of(ops)
+		}
 	}
 }


### PR DESCRIPTION
Data Root field in `V2::KateCommitment` could be `None`, reducing the header size on empty blocks.