### PR TITLE
Updated RPC Response Field Names to Use Camel Case

### DIFF
--- a/core/src/data_lookup/compact.rs
+++ b/core/src/data_lookup/compact.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Copy, Clone, Encode, Decode, TypeInfo, Constructor, Debug)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub struct DataLookupItem {
 	pub app_id: AppId,
 	#[codec(compact)]

--- a/core/src/data_proof.rs
+++ b/core/src/data_proof.rs
@@ -9,6 +9,7 @@ use thiserror_no_std::Error;
 /// Wrapper of `beefy-merkle-tree::MerkleProof` with codec support.
 #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, Default)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub struct DataProof {
 	/// Root hash of generated merkle tree.
 	pub root: H256,

--- a/core/src/header/extension/v1.rs
+++ b/core/src/header/extension/v1.rs
@@ -8,6 +8,7 @@ use crate::{v1::KateCommitment, DataLookup};
 
 #[derive(PartialEq, Eq, Clone, RuntimeDebug, TypeInfo, Encode, Decode, Default)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub struct HeaderExtension {
 	pub commitment: KateCommitment,
 	pub app_lookup: DataLookup,

--- a/core/src/header/extension/v2.rs
+++ b/core/src/header/extension/v2.rs
@@ -8,6 +8,7 @@ use crate::{v2::KateCommitment, DataLookup};
 
 #[derive(PartialEq, Eq, Clone, RuntimeDebug, TypeInfo, Encode, Decode, Default)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub struct HeaderExtension {
 	pub commitment: KateCommitment,
 	pub app_lookup: DataLookup,


### PR DESCRIPTION
Note: After merging this, avail-subxt api_dev needs to be updated via codegen