### PR TITLE
ChunkSize as Constant and some checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,6 +513,7 @@ dependencies = [
  "test-case",
  "thiserror-no-std",
  "tiny-keccak",
+ "trybuild",
 ]
 
 [[package]]
@@ -4214,6 +4215,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4ed310ef5ab98f5fa467900ed906cb9232dd5376597e00fd4cba2a449d06c0b"
 dependencies = [
  "hash-db",
+]
+
+[[package]]
+name = "trybuild"
+version = "1.0.96"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33a5f13f11071020bb12de7a16b925d2d58636175c20c11dc5f96cb64bb6c9b3"
+dependencies = [
+ "glob",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "termcolor",
+ "toml",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -485,7 +485,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "avail-core"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "avail-core",
  "binary-merkle-tree",
@@ -2124,7 +2124,7 @@ dependencies = [
 
 [[package]]
 name = "kate"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "avail-core",
  "criterion",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -39,6 +39,7 @@ rand.workspace = true
 serde_json.workspace = true
 test-case.workspace = true
 avail-core = { path = ".", features = ["runtime"] }
+trybuild = "1.0.96"
 
 [features]
 default = [ "std" ]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avail-core"
-version = "0.6.0"
+version = "0.6.1"
 authors = []
 edition = "2021"
 license = "Apache-2.0"

--- a/core/src/const_generic_asserts.rs
+++ b/core/src/const_generic_asserts.rs
@@ -1,0 +1,59 @@
+use core::mem::size_of;
+
+pub struct UsizeNonZero<const N: usize>;
+impl<const N: usize> UsizeNonZero<N> {
+	#[allow(dead_code)]
+	pub const OK: () = assert!(N != 0, "must be non-zero");
+}
+
+pub struct UsizeEven<const N: usize>;
+impl<const N: usize> UsizeEven<N> {
+	#[allow(dead_code)]
+	pub const OK: () = assert!(N % 2 == 0, "must be even");
+}
+
+pub struct USizeSafeCastToU32<const N: usize>;
+impl<const N: usize> USizeSafeCastToU32<N> {
+	#[allow(dead_code)]
+	pub const OK: () = assert!(
+		size_of::<usize>() <= size_of::<u32>() || N <= u32::MAX as usize,
+		"must be safe to cast to u32"
+	);
+}
+
+pub struct USizeGreaterOrEq<const N: usize, const M: usize>;
+impl<const N: usize, const M: usize> USizeGreaterOrEq<N, M> {
+	#[allow(dead_code)]
+	pub const OK: () = assert!(N >= M, "must be greater or equal");
+}
+
+#[cfg(test)]
+mod tests {
+	#[test]
+	fn non_zero() {
+		let t = trybuild::TestCases::new();
+		t.pass("tests/const_generics/usize_non_zero.rs");
+		t.compile_fail("tests/const_generics/usize_non_zero_fail.rs");
+	}
+
+	#[test]
+	fn even() {
+		let t = trybuild::TestCases::new();
+		t.pass("tests/const_generics/usize_even.rs");
+		t.compile_fail("tests/const_generics/usize_even_fail.rs");
+	}
+
+	#[test]
+	fn safe_cast_to_u32() {
+		let t = trybuild::TestCases::new();
+		t.pass("tests/const_generics/usize_safe_cast_to_u32.rs");
+		t.compile_fail("tests/const_generics/usize_safe_cast_to_u32_fail.rs");
+	}
+
+	#[test]
+	fn greater_or_eq() {
+		let t = trybuild::TestCases::new();
+		t.pass("tests/const_generics/usize_greater_or_eq.rs");
+		t.compile_fail("tests/const_generics/usize_greater_or_eq_fail.rs");
+	}
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -53,6 +53,8 @@ pub use constants::*;
 pub mod header_version;
 pub use header_version::HeaderVersion;
 
+pub mod const_generic_asserts;
+
 #[cfg(feature = "runtime")]
 pub mod bench_randomness;
 

--- a/core/tests/const_generics/usize_even.rs
+++ b/core/tests/const_generics/usize_even.rs
@@ -1,0 +1,10 @@
+use avail_core::const_generic_asserts::UsizeEven;
+
+fn const_generic_even<const N: usize>() {
+	let () = UsizeEven::<N>::OK;
+}
+
+fn main() {
+	const_generic_even::<2>();
+	const_generic_even::<4>();
+}

--- a/core/tests/const_generics/usize_even_fail.rs
+++ b/core/tests/const_generics/usize_even_fail.rs
@@ -1,0 +1,9 @@
+use avail_core::const_generic_asserts::UsizeEven;
+
+fn const_generic_even<const N: usize> () {
+	let () = UsizeEven::<N>::OK;
+}
+
+fn main () {
+	const_generic_even::<1>();
+}

--- a/core/tests/const_generics/usize_even_fail.stderr
+++ b/core/tests/const_generics/usize_even_fail.stderr
@@ -1,0 +1,13 @@
+error[E0080]: evaluation of `avail_core::const_generic_asserts::UsizeEven::<1>::OK` failed
+ --> src/const_generic_asserts.rs
+  |
+  |     pub const OK: () = assert!(N % 2 == 0, "must be even");
+  |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'must be even', $DIR/src/const_generic_asserts.rs:12:24
+  |
+  = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+note: the above error was encountered while instantiating `fn const_generic_even::<1>`
+ --> tests/const_generics/usize_even_fail.rs:8:2
+  |
+8 |     const_generic_even::<1>();
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/core/tests/const_generics/usize_greater_or_eq.rs
+++ b/core/tests/const_generics/usize_greater_or_eq.rs
@@ -1,0 +1,15 @@
+use avail_core::const_generic_asserts::USizeGreaterOrEq;
+
+fn const_generic_ge<const N: usize, const M: usize>() {
+	let () = USizeGreaterOrEq::<N, M>::OK;
+}
+
+fn main() {
+	const_generic_ge::<0, 0>();
+	const_generic_ge::<1, 0>();
+	const_generic_ge::<1, 1>();
+	const_generic_ge::<100, 99>();
+	const_generic_ge::<100, 100>();
+	const_generic_ge::<{ usize::MAX }, { usize::MAX - 1 }>();
+	const_generic_ge::<{ usize::MAX }, { usize::MAX }>();
+}

--- a/core/tests/const_generics/usize_greater_or_eq_fail.rs
+++ b/core/tests/const_generics/usize_greater_or_eq_fail.rs
@@ -1,0 +1,9 @@
+use avail_core::const_generic_asserts::USizeGreaterOrEq;
+
+fn const_generic_ge<const N: usize, const M: usize> () {
+	let () = USizeGreaterOrEq::<N,M>::OK;
+}
+
+fn main () {
+	const_generic_ge::<1, 2>();
+}

--- a/core/tests/const_generics/usize_greater_or_eq_fail.stderr
+++ b/core/tests/const_generics/usize_greater_or_eq_fail.stderr
@@ -1,0 +1,13 @@
+error[E0080]: evaluation of `avail_core::const_generic_asserts::USizeGreaterOrEq::<1, 2>::OK` failed
+ --> src/const_generic_asserts.rs
+  |
+  |     pub const OK: () = assert!(N >= M, "must be greater or equal");
+  |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'must be greater or equal', $DIR/src/const_generic_asserts.rs:27:24
+  |
+  = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+note: the above error was encountered while instantiating `fn const_generic_ge::<1, 2>`
+ --> tests/const_generics/usize_greater_or_eq_fail.rs:8:2
+  |
+8 |     const_generic_ge::<1, 2>();
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/core/tests/const_generics/usize_non_zero.rs
+++ b/core/tests/const_generics/usize_non_zero.rs
@@ -1,0 +1,10 @@
+use avail_core::const_generic_asserts::UsizeNonZero;
+
+fn const_generic_non_zero<const N: usize>() {
+	let () = UsizeNonZero::<N>::OK;
+}
+
+fn main() {
+	const_generic_non_zero::<1>();
+	const_generic_non_zero::<2>();
+}

--- a/core/tests/const_generics/usize_non_zero_fail.rs
+++ b/core/tests/const_generics/usize_non_zero_fail.rs
@@ -1,0 +1,9 @@
+use avail_core::const_generic_asserts::UsizeNonZero;
+
+fn const_generic_non_zero<const N: usize> () {
+	let () = UsizeNonZero::<N>::OK;
+}
+
+fn main () {
+	const_generic_non_zero::<0>();
+}

--- a/core/tests/const_generics/usize_non_zero_fail.stderr
+++ b/core/tests/const_generics/usize_non_zero_fail.stderr
@@ -1,0 +1,13 @@
+error[E0080]: evaluation of `avail_core::const_generic_asserts::UsizeNonZero::<0>::OK` failed
+ --> src/const_generic_asserts.rs
+  |
+  |     pub const OK: () = assert!(N != 0, "must be non-zero");
+  |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'must be non-zero', $DIR/src/const_generic_asserts.rs:6:24
+  |
+  = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+note: the above error was encountered while instantiating `fn const_generic_non_zero::<0>`
+ --> tests/const_generics/usize_non_zero_fail.rs:8:2
+  |
+8 |     const_generic_non_zero::<0>();
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/core/tests/const_generics/usize_safe_cast_to_u32.rs
+++ b/core/tests/const_generics/usize_safe_cast_to_u32.rs
@@ -1,0 +1,11 @@
+use avail_core::const_generic_asserts::USizeSafeCastToU32;
+
+fn const_generic_safe_cast_to_u32<const N: usize>() {
+	let () = USizeSafeCastToU32::<N>::OK;
+}
+
+fn main() {
+	const_generic_safe_cast_to_u32::<0>();
+	const_generic_safe_cast_to_u32::<{ (u32::MAX - 1) as usize }>();
+	const_generic_safe_cast_to_u32::<{ u32::MAX as usize }>();
+}

--- a/core/tests/const_generics/usize_safe_cast_to_u32_fail.rs
+++ b/core/tests/const_generics/usize_safe_cast_to_u32_fail.rs
@@ -1,0 +1,9 @@
+use avail_core::const_generic_asserts::USizeSafeCastToU32;
+
+fn const_generic_safe_cast_to_u32<const N: usize>() {
+	let () = USizeSafeCastToU32::<N>::OK;
+}
+
+fn main() {
+	const_generic_safe_cast_to_u32::<{ u32::MAX as usize +  1 }>();
+}

--- a/core/tests/const_generics/usize_safe_cast_to_u32_fail.stderr
+++ b/core/tests/const_generics/usize_safe_cast_to_u32_fail.stderr
@@ -1,0 +1,17 @@
+error[E0080]: evaluation of `avail_core::const_generic_asserts::USizeSafeCastToU32::<4294967296>::OK` failed
+ --> src/const_generic_asserts.rs
+  |
+  |       pub const OK: () = assert!(
+  |  ________________________^
+  | |         size_of::<usize>() <= size_of::<u32>() || N <= u32::MAX as usize,
+  | |         "must be safe to cast to u32"
+  | |     );
+  | |_____^ the evaluated program panicked at 'must be safe to cast to u32', $DIR/src/const_generic_asserts.rs:18:24
+  |
+  = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+note: the above error was encountered while instantiating `fn const_generic_safe_cast_to_u32::<4294967296>`
+ --> tests/const_generics/usize_safe_cast_to_u32_fail.rs:8:2
+  |
+8 |     const_generic_safe_cast_to_u32::<{ u32::MAX as usize +  1 }>();
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/kate/Cargo.toml
+++ b/kate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kate"
-version = "0.8.2"
+version = "0.9.0"
 authors = ["Denis Ermolin <denis.ermolin@matic.network>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/kate/benches/reconstruct.rs
+++ b/kate/benches/reconstruct.rs
@@ -1,5 +1,4 @@
 use avail_core::{AppExtrinsic, AppId, BlockLengthColumns, BlockLengthRows, DataLookup};
-use core::num::NonZeroU32;
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use dusk_plonk::prelude::BlsScalar;
 use kate::{
@@ -128,10 +127,9 @@ fn bench_reconstruct(c: &mut Criterion) {
 
 fn reconstruct(xts: &[AppExtrinsic]) {
 	let metrics = IgnoreMetrics {};
-	let (layout, commitments, dims, matrix) = par_build_commitments(
+	let (layout, commitments, dims, matrix) = par_build_commitments::<32, _>(
 		BlockLengthRows(64),
 		BlockLengthColumns(16),
-		unsafe { NonZeroU32::new_unchecked(32) },
 		xts,
 		Seed::default(),
 		&metrics,

--- a/kate/src/com.rs
+++ b/kate/src/com.rs
@@ -1163,7 +1163,7 @@ Let's see how this gets encoded and then reconstructed by sampling only some dat
 		extrinsics
 			.into_iter()
 			.flat_map(pad_iec_9797_1)
-			.map(|chunk| pad_to_chunk::<32>(chunk).len())
+			.map(|chunk| pad_to_chunk::<TCHUNK_SIZE>(chunk).len())
 			.sum::<usize>()
 			.saturated_into()
 	}
@@ -1231,7 +1231,6 @@ Let's see how this gets encoded and then reconstructed by sampling only some dat
 		println!("Row: {:?}", row);
 		let commitment: [u8; config::COMMITMENT_SIZE] =
 			commit(&prover_key, row_eval_domain, row.clone())
-				// .map(|com| <[u8; config::COMMITMENT_SIZE]>::try_from(com.to_bytes()).unwrap())
 				.map(|com| com.to_bytes())
 				.unwrap();
 		println!("Commitment: {commitment:?}");


### PR DESCRIPTION
`ChunkSize` is now a constant and its constraints are now checked in compilation time.

NOTE: Static assertions of constant generics are not supported by `static_assertions`, so I've defined them inside `avail-core::const_generics`. I've also added compilation tests to double-check the expected behaviour of those static assertions. 