### PR TITLE
Upgrade PMP from upstream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -704,8 +704,9 @@ dependencies = [
 
 [[package]]
 name = "blst"
-version = "0.3.10"
-source = "git+https://github.com/availproject/blst?tag=v0.3.10#556e037926d9c526c2eb6cb1522bea39690416ea"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4378725facc195f1a538864863f6de233b500a8862747e7f165078a419d5e874"
 dependencies = [
  "cc",
  "glob",
@@ -2655,7 +2656,6 @@ checksum = "626dec3cac7cc0e1577a2ec3fc496277ec2baa084bebad95bb6fdbfae235f84c"
 [[package]]
 name = "poly-multiproof"
 version = "0.0.1"
-source = "git+https://github.com/availproject/poly-multiproof?tag=v0.0.1#cd8d31b7eb568dea2fddfc9237e2e31ea7ae7ed3"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",
@@ -2665,6 +2665,7 @@ dependencies = [
  "ark-std",
  "blst",
  "merlin 3.0.0",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2661,7 +2661,7 @@ checksum = "626dec3cac7cc0e1577a2ec3fc496277ec2baa084bebad95bb6fdbfae235f84c"
 [[package]]
 name = "poly-multiproof"
 version = "0.1.1"
-source = "git+https://github.com/aphoh/poly-multiproof?tag=v0.1.1#0e46c89762b5531b1767e4e8e923e0ed982f0e49"
+source = "git+https://github.com/availproject/poly-multiproof#0e46c89762b5531b1767e4e8e923e0ed982f0e49"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,7 +136,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -458,7 +458,7 @@ checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1116,7 +1116,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1240,7 +1240,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.48",
+ "syn 2.0.96",
  "termcolor",
  "toml",
  "walkdir",
@@ -1465,7 +1465,7 @@ dependencies = [
  "fs-err",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1611,7 +1611,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sp-crypto-hashing",
- "syn 2.0.48",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1623,7 +1623,7 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1633,7 +1633,7 @@ source = "git+https://github.com/availproject/polkadot-sdk?tag=polkadot-1.7.1-pa
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1708,7 +1708,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2126,7 +2126,6 @@ dependencies = [
 name = "kate"
 version = "0.9.2"
 dependencies = [
- "ark-bls12-381",
  "avail-core",
  "criterion",
  "derive_more",
@@ -2297,7 +2296,7 @@ dependencies = [
  "macro_magic_core",
  "macro_magic_macros",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2311,7 +2310,7 @@ dependencies = [
  "macro_magic_core_macros",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2322,7 +2321,7 @@ checksum = "9ea73aa640dc01d62a590d48c0c3521ed739d53b27f919b25c3551e233481654"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2333,7 +2332,7 @@ checksum = "ef9d79ae96aaba821963320eb2b6e34d17df1e5a83d8a1985c29cc5be59577b3"
 dependencies = [
  "macro_magic_core",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2671,7 +2670,7 @@ checksum = "626dec3cac7cc0e1577a2ec3fc496277ec2baa084bebad95bb6fdbfae235f84c"
 [[package]]
 name = "poly-multiproof"
 version = "0.1.1"
-source = "git+https://github.com/availproject/poly-multiproof#0e46c89762b5531b1767e4e8e923e0ed982f0e49"
+source = "git+https://github.com/aphoh/poly-multiproof#494468b86ac8e16dca21d465d921990c578eaad3"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",
@@ -2681,7 +2680,7 @@ dependencies = [
  "ark-std",
  "blst",
  "merlin 3.0.0",
- "thiserror",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -2763,14 +2762,14 @@ checksum = "834da187cfe638ae8abb0203f0b33e5ccdb02a28e7199f2f47b3e2754f50edca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
@@ -2922,7 +2921,7 @@ checksum = "5fddb4f8d99b0a2ebafc65a87a69a7b9875e4b1ae1f00db265d300ef7f28bccc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -3237,7 +3236,7 @@ checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -3376,7 +3375,7 @@ dependencies = [
  "sp-std",
  "sp-trie",
  "sp-version",
- "thiserror",
+ "thiserror 1.0.57",
 ]
 
 [[package]]
@@ -3390,7 +3389,7 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -3478,7 +3477,7 @@ dependencies = [
  "sp-storage",
  "ss58-registry",
  "substrate-bip39",
- "thiserror",
+ "thiserror 1.0.57",
  "tracing",
  "w3f-bls",
  "zeroize",
@@ -3525,7 +3524,7 @@ source = "git+https://github.com/availproject/polkadot-sdk?tag=polkadot-1.7.1-pa
 dependencies = [
  "quote",
  "sp-crypto-hashing",
- "syn 2.0.48",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -3535,7 +3534,7 @@ source = "git+https://github.com/availproject/polkadot-sdk?tag=polkadot-1.7.1-pa
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -3571,7 +3570,7 @@ dependencies = [
  "scale-info",
  "sp-runtime",
  "sp-std",
- "thiserror",
+ "thiserror 1.0.57",
 ]
 
 [[package]]
@@ -3608,7 +3607,7 @@ dependencies = [
  "parking_lot",
  "sp-core",
  "sp-externalities",
- "thiserror",
+ "thiserror 1.0.57",
 ]
 
 [[package]]
@@ -3684,7 +3683,7 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -3717,7 +3716,7 @@ dependencies = [
  "sp-panic-handler",
  "sp-std",
  "sp-trie",
- "thiserror",
+ "thiserror 1.0.57",
  "tracing",
  "trie-db",
 ]
@@ -3770,7 +3769,7 @@ dependencies = [
  "sp-core",
  "sp-externalities",
  "sp-std",
- "thiserror",
+ "thiserror 1.0.57",
  "tracing",
  "trie-db",
  "trie-root",
@@ -3790,7 +3789,7 @@ dependencies = [
  "sp-runtime",
  "sp-std",
  "sp-version-proc-macro",
- "thiserror",
+ "thiserror 1.0.57",
 ]
 
 [[package]]
@@ -3801,7 +3800,7 @@ dependencies = [
  "parity-scale-codec",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -3901,9 +3900,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "2.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3968,7 +3967,16 @@ version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.57",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+dependencies = [
+ "thiserror-impl 2.0.11",
 ]
 
 [[package]]
@@ -3979,7 +3987,18 @@ checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -4141,7 +4160,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -4345,7 +4364,7 @@ dependencies = [
  "rand_core 0.6.4",
  "sha2 0.10.8",
  "sha3",
- "thiserror",
+ "thiserror 1.0.57",
  "zeroize",
 ]
 
@@ -4395,7 +4414,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.96",
  "wasm-bindgen-shared",
 ]
 
@@ -4417,7 +4436,7 @@ checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.96",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4486,7 +4505,7 @@ dependencies = [
  "object 0.30.4",
  "serde",
  "target-lexicon",
- "thiserror",
+ "thiserror 1.0.57",
  "wasmparser",
  "wasmtime-types",
 ]
@@ -4566,7 +4585,7 @@ checksum = "a4f6fffd2a1011887d57f07654dd112791e872e3ff4a2e626aee8059ee17f06f"
 dependencies = [
  "cranelift-entity",
  "serde",
- "thiserror",
+ "thiserror 1.0.57",
  "wasmparser",
 ]
 
@@ -4862,7 +4881,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -4882,5 +4901,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.96",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,8 +49,9 @@ blake2b_simd = { version = "1.0.2", default-features = false }
 sha2 = { version = "0.10.7", default-features = false }
 sha3 = { version = "0.10.0", default-features = false }
 
-poly-multiproof = { git = "https://github.com/availproject/poly-multiproof", ref="0e46c89762b5531b1767e4e8e923e0ed982f0e49", default-features = false, features = ['ark-bls12-381']}
-ark-bls12-381 = { version = "0.4.0" }
+#poly-multiproof = { git = "https://github.com/availproject/poly-multiproof", ref="0e46c89762b5531b1767e4e8e923e0ed982f0e49", default-features = false, features = ['ark-bls12-381']}
+poly-multiproof = { git = "https://github.com/aphoh/poly-multiproof", ref="494468b86ac8e16dca21d465d921990c578eaad3", default-features = false, features = ['ark-bls12-381']}
+#poly-multiproof = { path = "../../poly-multiproof", default-features = false, features = ['ark-bls12-381']}
 dusk-plonk = { git = "https://github.com/availproject/plonk.git", tag = "v0.12.0-polygon-2" }
 
 hash-db = { version = "0.16.0",  default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ tiny-keccak = { version = "2.0.2", default-features = false, features = ["keccak
 rand = { version = "0.8.4", features = ["alloc", "small_rng"], default-features = false }
 rand_chacha = { version = "0.3", default-features = false }
 
-poly-multiproof = { git = "https://github.com/availproject/poly-multiproof", default-features = false, tag = "v0.0.1" }
+poly-multiproof = { path = "../poly-multiproof", default-features = false}
 dusk-plonk = { git = "https://github.com/availproject/plonk.git", tag = "v0.12.0-polygon-2" }
 
 # Others

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,8 +43,7 @@ tiny-keccak = { version = "2.0.2", default-features = false, features = ["keccak
 rand = { version = "0.8.4", features = ["alloc", "small_rng"], default-features = false }
 rand_chacha = { version = "0.3", default-features = false }
 
-poly-multiproof = { git = "https://github.com/aphoh/poly-multiproof", tag="v0.1.1", default-features = false, features = ['ark-bls12-381']}
-#poly-multiproof = { path="../../poly-multiproof", default-features = false, features = ['ark-bls12-381']}
+poly-multiproof = { git = "https://github.com/availproject/poly-multiproof", ref="0e46c89762b5531b1767e4e8e923e0ed982f0e49", default-features = false, features = ['ark-bls12-381']}
 ark-bls12-381 = { version = "0.4.0" }
 dusk-plonk = { git = "https://github.com/availproject/plonk.git", tag = "v0.12.0-polygon-2" }
 

--- a/kate/Cargo.toml
+++ b/kate/Cargo.toml
@@ -15,7 +15,6 @@ kate-recovery = { path = "recovery", default-features = false }
 # Crypto
 dusk-plonk = { workspace = true, optional = true }
 poly-multiproof = { workspace = true, optional = true }
-ark-bls12-381 = { workspace = true, optional = true }
 
 # Parity & Substrate
 codec = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
@@ -60,9 +59,8 @@ std = [
 	"nalgebra/std",
 	"once_cell",
 	"parallel",
-	"poly-multiproof/blst",
 	"poly-multiproof/std",
-	"ark-bls12-381/std",
+	"poly-multiproof/blst",
 	"rand/std",
 	"rand_chacha/std",
 	"serde",

--- a/kate/Cargo.toml
+++ b/kate/Cargo.toml
@@ -61,6 +61,7 @@ std = [
 	"once_cell",
 	"parallel",
 	"poly-multiproof/blst",
+	"poly-multiproof/std",
 	"rand/std",
 	"rand_chacha/std",
 	"serde",

--- a/kate/examples/multiproof_verification.rs
+++ b/kate/examples/multiproof_verification.rs
@@ -9,9 +9,9 @@ use kate::{
 	Seed,
 };
 use kate_recovery::matrix::Dimensions;
+use poly_multiproof::method1::M1NoPrecomp;
 use poly_multiproof::msm::blst::BlstMSMEngine;
 use poly_multiproof::traits::AsBytes;
-use poly_multiproof::{method1::M1NoPrecomp};
 use rand::thread_rng;
 use thiserror_no_std::Error;
 

--- a/kate/src/gridgen/mod.rs
+++ b/kate/src/gridgen/mod.rs
@@ -346,17 +346,14 @@ impl PolynomialGrid {
 			.iter()
 			.map(|row| row.iter().map(|&s| E::ScalarField::from(s)).collect())
 			.collect();
-
-		let evals: Vec<Vec<E::ScalarField>> = self.inner[block.start_y..block.end_y]
-			.iter()
-			.map(|row| {
-				row[block.start_x..block.end_x]
+		let evals: Vec<Vec<E::ScalarField>> = (block.start_y..block.end_y)
+			.map(|y| {
+				eval_grid.row(y).expect("Already bounds checked .qed")[block.start_x..block.end_x]
 					.iter()
-					.map(|&s| E::ScalarField::from(s))
-					.collect()
+					.map(|&scalar| E::ScalarField::from(scalar))
+					.collect::<Vec<_>>()
 			})
-			.collect();
-
+			.collect::<Vec<_>>();
 		let points: Vec<E::ScalarField> = self.points[block.start_x..block.end_x]
 			.iter()
 			.map(|&p| E::ScalarField::from(p))

--- a/kate/src/gridgen/mod.rs
+++ b/kate/src/gridgen/mod.rs
@@ -1,9 +1,9 @@
 use crate::pmp::{
-	Pairing,
 	ark_poly::{EvaluationDomain, GeneralEvaluationDomain},
 	merlin::Transcript,
 	method1::M1NoPrecomp,
 	traits::{Committer, MSMEngine},
+	Pairing,
 };
 use ark_bls12_381::{Bls12_381, Fr};
 use avail_core::{

--- a/kate/src/gridgen/mod.rs
+++ b/kate/src/gridgen/mod.rs
@@ -1,11 +1,11 @@
 use crate::pmp::{
+	ark_bls12_381::{Bls12_381, Fr},
 	ark_poly::{EvaluationDomain, GeneralEvaluationDomain},
 	merlin::Transcript,
 	method1::M1NoPrecomp,
 	traits::{Committer, MSMEngine},
 	Pairing,
 };
-use ark_bls12_381::{Bls12_381, Fr};
 use avail_core::{
 	app_extrinsic::AppExtrinsic, constants::kate::DATA_CHUNK_SIZE, ensure, AppId, DataLookup,
 };

--- a/kate/src/gridgen/tests/mod.rs
+++ b/kate/src/gridgen/tests/mod.rs
@@ -1,7 +1,7 @@
 use avail_core::{AppExtrinsic, AppId};
 use kate_recovery::{data::DataCell, matrix::Position};
 use once_cell::sync::Lazy;
-use poly_multiproof::{m1_blst::M1NoPrecomp, traits::AsBytes};
+use poly_multiproof::{method1::M1NoPrecomp, traits::AsBytes};
 use proptest::{collection, prelude::*, sample::size_range};
 use rand::{distributions::Uniform, prelude::Distribution, SeedableRng};
 use rand_chacha::ChaChaRng;

--- a/kate/src/lib.rs
+++ b/kate/src/lib.rs
@@ -225,8 +225,7 @@ pub mod couscous {
 	pub fn multiproof_params<E: Pairing<G1 = G1, G2 = G2>, M: MSMEngine<E = E>>(
 	) -> M1NoPrecomp<E, M> {
 		let (g1, g2) = load_trusted_g1_g2();
-		let x = <M1NoPrecomp<_, _>>::new_from_powers(&g1, &g2);
-		x
+		<M1NoPrecomp<_, _>>::new_from_powers(&g1, &g2)
 	}
 
 	#[cfg(test)]

--- a/kate/src/lib.rs
+++ b/kate/src/lib.rs
@@ -23,8 +23,9 @@ pub use dusk_bytes::Serializable;
 #[cfg(feature = "std")]
 pub use poly_multiproof as pmp;
 
-#[cfg(all(feature = "std", feature="ark-bls12-381"))]
-pub type M1NoPrecomp = pmp::method1::M1NoPrecomp<ark_bls12_381::Bls12_381, pmp::msm::blst::BlstMSMEngine>;
+#[cfg(all(feature = "std", feature = "ark-bls12-381"))]
+pub type M1NoPrecomp =
+	pmp::method1::M1NoPrecomp<ark_bls12_381::Bls12_381, pmp::msm::blst::BlstMSMEngine>;
 
 pub mod config {
 	use super::{BlockLengthColumns, BlockLengthRows};

--- a/kate/src/lib.rs
+++ b/kate/src/lib.rs
@@ -54,7 +54,7 @@ pub mod testnet {
 	use super::*;
 	use hex_literal::hex;
 	use once_cell::sync::Lazy;
-	use poly_multiproof::ark_bls12_381::{Fr, G1Projective as G1, G2Projective as G2};
+	use poly_multiproof::ark_bls12_381::Fr;
 	use poly_multiproof::ark_ec::pairing::Pairing;
 	use poly_multiproof::ark_ff::{BigInt, Fp, PrimeField};
 	use poly_multiproof::ark_serialize::CanonicalDeserialize;
@@ -98,8 +98,8 @@ pub mod testnet {
 		E::G1: CanonicalDeserialize,
 		E::G2: CanonicalDeserialize,
 	{
-		let x: E::ScalarField = E::ScalarField::from(Fr::from(BigInt(SEC_LIMBS)));
-
+		let x: <E as Pairing>::ScalarField =
+			Fp(BigInt(SEC_LIMBS), core::marker::PhantomData).into();
 		let g1: E::G1 = E::G1::deserialize_compressed(&G1_BYTES[..]).unwrap();
 		let g2: E::G2 = E::G2::deserialize_compressed(&G2_BYTES[..]).unwrap();
 
@@ -117,10 +117,10 @@ pub mod testnet {
 			prelude::BlsScalar,
 		};
 		use poly_multiproof::{
+			ark_ec::pairing::Pairing,
 			ark_ff::{BigInt, Fp},
 			ark_poly::{EvaluationDomain, GeneralEvaluationDomain},
 			ark_serialize::{CanonicalDeserialize, CanonicalSerialize},
-			m1_blst::Fr,
 			traits::Committer,
 		};
 		use rand::thread_rng;
@@ -135,10 +135,10 @@ pub mod testnet {
 				hex!("7848b5d711bc9883996317a3f9c90269d56771005d540a19184939c9e8d0db2a");
 			assert_eq!(SEC_BYTES, out);
 
-			let g1 = G1::deserialize_compressed(&G1_BYTES[..]).unwrap();
-			let g2 = G2::deserialize_compressed(&G2_BYTES[..]).unwrap();
+			let g1 = Pairing::G1::deserialize_compressed(&G1_BYTES[..]).unwrap();
+			let g2 = Pairing::G2::deserialize_compressed(&G2_BYTES[..]).unwrap();
 
-			let pmp = poly_multiproof::m1_blst::M1NoPrecomp::new_from_scalar(x, g1, g2, 1024, 256);
+			let pmp = poly_multiproof::method1::M1NoPrecomp::new_from_scalar(x, g1, g2, 1024, 256);
 
 			let dp_evals = (0..30)
 				.map(|_| BlsScalar::random(&mut thread_rng()))
@@ -242,7 +242,7 @@ pub mod couscous {
 			traits::KZGProof,
 		};
 		use poly_multiproof::{
-			m1_blst::Fr,
+			ark_bls12_381::Fr,
 			traits::{AsBytes, Committer},
 		};
 		use rand::thread_rng;

--- a/kate/src/lib.rs
+++ b/kate/src/lib.rs
@@ -1,7 +1,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![deny(clippy::arithmetic_side_effects)]
 
-use ark_bls12_381::Bls12_381;
 use avail_core::{constants::kate::DATA_CHUNK_SIZE, BlockLengthColumns, BlockLengthRows};
 use core::{
 	convert::TryInto,
@@ -24,7 +23,8 @@ pub use dusk_bytes::Serializable;
 #[cfg(feature = "std")]
 pub use poly_multiproof as pmp;
 
-pub type M1NoPrecomp = pmp::method1::M1NoPrecomp<Bls12_381, pmp::msm::blst::BlstMSMEngine>;
+#[cfg(all(feature = "std", feature="ark-bls12-381"))]
+pub type M1NoPrecomp = pmp::method1::M1NoPrecomp<ark_bls12_381::Bls12_381, pmp::msm::blst::BlstMSMEngine>;
 
 pub mod config {
 	use super::{BlockLengthColumns, BlockLengthRows};

--- a/kate/src/lib.rs
+++ b/kate/src/lib.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![deny(clippy::arithmetic_side_effects)]
 
+use ark_bls12_381::Bls12_381;
 use avail_core::{constants::kate::DATA_CHUNK_SIZE, BlockLengthColumns, BlockLengthRows};
 use core::{
 	convert::TryInto,
@@ -22,6 +23,8 @@ pub type Seed = [u8; 32];
 pub use dusk_bytes::Serializable;
 #[cfg(feature = "std")]
 pub use poly_multiproof as pmp;
+
+pub type M1NoPrecomp = pmp::method1::M1NoPrecomp<Bls12_381, pmp::msm::blst::BlstMSMEngine>;
 
 pub mod config {
 	use super::{BlockLengthColumns, BlockLengthRows};

--- a/kate/src/lib.rs
+++ b/kate/src/lib.rs
@@ -115,12 +115,12 @@ pub mod testnet {
 		use core::marker::PhantomData;
 
 		use super::*;
-		use pmp::ark_bls12_381::Bls12_381;
 		use dusk_bytes::Serializable;
 		use dusk_plonk::{
 			fft::{EvaluationDomain as PlonkED, Evaluations as PlonkEV},
 			prelude::BlsScalar,
 		};
+		use pmp::ark_bls12_381::Bls12_381;
 		use poly_multiproof::{
 			ark_ff::{BigInt, Fp},
 			ark_poly::{EvaluationDomain, GeneralEvaluationDomain},

--- a/kate/src/lib.rs
+++ b/kate/src/lib.rs
@@ -23,9 +23,9 @@ pub use dusk_bytes::Serializable;
 #[cfg(feature = "std")]
 pub use poly_multiproof as pmp;
 
-#[cfg(all(feature = "std", feature = "ark-bls12-381"))]
+#[cfg(feature = "std")]
 pub type M1NoPrecomp =
-	pmp::method1::M1NoPrecomp<ark_bls12_381::Bls12_381, pmp::msm::blst::BlstMSMEngine>;
+	pmp::method1::M1NoPrecomp<pmp::ark_bls12_381::Bls12_381, pmp::msm::blst::BlstMSMEngine>;
 
 pub mod config {
 	use super::{BlockLengthColumns, BlockLengthRows};
@@ -56,9 +56,9 @@ pub mod config {
 #[cfg(feature = "std")]
 pub mod testnet {
 	use super::*;
-	use ark_bls12_381::Fr;
 	use hex_literal::hex;
 	use once_cell::sync::Lazy;
+	use pmp::ark_bls12_381::Fr;
 	use poly_multiproof::ark_ff::{BigInt, Fp, PrimeField};
 	use poly_multiproof::ark_serialize::CanonicalDeserialize;
 	use poly_multiproof::method1::M1NoPrecomp;
@@ -115,7 +115,7 @@ pub mod testnet {
 		use core::marker::PhantomData;
 
 		use super::*;
-		use ark_bls12_381::Bls12_381;
+		use pmp::ark_bls12_381::Bls12_381;
 		use dusk_bytes::Serializable;
 		use dusk_plonk::{
 			fft::{EvaluationDomain as PlonkED, Evaluations as PlonkEV},
@@ -181,11 +181,11 @@ pub mod testnet {
 #[cfg(feature = "std")]
 pub mod couscous {
 	use super::*;
-	use ark_bls12_381::{G1Projective as G1, G2Projective as G2};
-	use poly_multiproof::ark_serialize::CanonicalDeserialize;
-	use poly_multiproof::method1::M1NoPrecomp;
-	use poly_multiproof::traits::MSMEngine;
-	use poly_multiproof::Pairing;
+	use pmp::ark_bls12_381::{G1Projective as G1, G2Projective as G2};
+	use pmp::ark_serialize::CanonicalDeserialize;
+	use pmp::method1::M1NoPrecomp;
+	use pmp::traits::MSMEngine;
+	use pmp::Pairing;
 	/// Constructs public parameters from pre-generated points for degree upto 1024
 	pub fn public_params() -> PublicParameters {
 		// We can also use the raw data to make deserilization faster at the cost of size of the data


### PR DESCRIPTION
Various changes were made to `poly-multiproof` for the newest multiproof method. This updates `avail-core` to those upstream changes.