### PR TITLE
Add proof verification using ark primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2173,6 +2173,7 @@ dependencies = [
  "hex",
  "once_cell",
  "parity-scale-codec",
+ "poly-multiproof",
  "rand",
  "rand_chacha",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2156,6 +2156,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-arithmetic",
+ "sp-std",
  "static_assertions",
  "test-case",
  "thiserror-no-std",

--- a/core/src/opaque_extrinsic.rs
+++ b/core/src/opaque_extrinsic.rs
@@ -1,8 +1,11 @@
-use crate::from_substrate::HexDisplay;
 use codec::{Decode, Encode};
-use scale_info::prelude::format;
 use scale_info::TypeInfo;
 use sp_std::vec::Vec;
+
+#[cfg(feature = "std")]
+use crate::from_substrate::HexDisplay;
+#[cfg(feature = "serde")]
+use scale_info::prelude::format;
 
 /// Simple blob to hold an extrinsic without committing to its format and ensure it is serialized
 /// correctly.

--- a/kate/Cargo.toml
+++ b/kate/Cargo.toml
@@ -39,6 +39,7 @@ serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 
 [dev-dependencies]
+avail-core = { path = "../core", default-features = false, features = ["runtime"]}
 criterion.workspace = true
 proptest.workspace = true
 serde_json.workspace = true

--- a/kate/Cargo.toml
+++ b/kate/Cargo.toml
@@ -13,12 +13,13 @@ avail-core = { path = "../core", default-features = false }
 kate-recovery = { path = "recovery", default-features = false }
 
 # Crypto
-dusk-plonk = { workspace = true, optional = true }
-poly-multiproof = { workspace = true, optional = true }
+dusk-plonk = { workspace = true }
+poly-multiproof = { workspace = true, default-features = false, features = ["blst"] }
 
 # Parity & Substrate
 codec = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 sp-arithmetic.workspace = true
+sp-std.workspace = true
 
 # 3rd-party
 derive_more.workspace = true
@@ -26,7 +27,7 @@ static_assertions.workspace = true
 thiserror-no-std.workspace = true
 
 dusk-bytes = { workspace = true, optional = true }
-hex = { workspace = true, optional = true }
+hex = { workspace = true }
 hex-literal.workspace = true
 log = { workspace = true, optional = true }
 nalgebra = { workspace = true, optional = true }
@@ -53,7 +54,6 @@ std = [
 	"codec/std",
 	"dusk-bytes",
 	"dusk-plonk/std",
-	"hex",
 	"kate-recovery/std",
 	"log",
 	"nalgebra/std",

--- a/kate/benches/reconstruct.rs
+++ b/kate/benches/reconstruct.rs
@@ -1,11 +1,8 @@
 use avail_core::{AppExtrinsic, AppId, BlockLengthColumns, BlockLengthRows, DataLookup};
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use dusk_plonk::prelude::BlsScalar;
-use kate::{
-	com::{Cell, *},
-	metrics::IgnoreMetrics,
-	Seed, Serializable as _,
-};
+use kate::dusk_bytes::Serializable as _;
+use kate::{com::build_proof, com::par_build_commitments, com::Cell, metrics::IgnoreMetrics, Seed};
 use kate_recovery::{
 	com::reconstruct_extrinsics,
 	commitments,

--- a/kate/recovery/Cargo.toml
+++ b/kate/recovery/Cargo.toml
@@ -9,6 +9,7 @@ license = "Apache-2.0"
 # Internals
 avail-core = { path = "../../core", default-features = false }
 dusk-plonk = { workspace = true }
+poly-multiproof = { workspace = true, default-features = false, features = ["blst"] }
 
 # Parity
 codec = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }

--- a/kate/recovery/src/commitments.rs
+++ b/kate/recovery/src/commitments.rs
@@ -1,10 +1,12 @@
-use avail_core::constants::kate::{CHUNK_SIZE, COMMITMENT_SIZE};
+use avail_core::constants::kate::COMMITMENT_SIZE;
 use core::{array::TryFromSliceError, convert::TryInto, num::TryFromIntError};
 use sp_std::prelude::*;
 use thiserror_no_std::Error;
 
 #[cfg(feature = "std")]
 use crate::{com, matrix};
+#[cfg(feature = "std")]
+use avail_core::constants::kate::CHUNK_SIZE;
 #[cfg(feature = "std")]
 use avail_core::{ensure, AppId, DataLookup};
 #[cfg(feature = "std")]

--- a/kate/recovery/src/proof.rs
+++ b/kate/recovery/src/proof.rs
@@ -1,3 +1,9 @@
+use thiserror_no_std::Error;
+
+#[cfg(feature = "std")]
+use crate::{data::Cell, matrix::Dimensions};
+#[cfg(feature = "std")]
+use avail_core::constants::kate::COMMITMENT_SIZE;
 #[cfg(feature = "std")]
 use dusk_bytes::Serializable;
 #[cfg(feature = "std")]
@@ -7,20 +13,18 @@ use dusk_plonk::{
 	fft::EvaluationDomain,
 	prelude::BlsScalar,
 };
-use thiserror_no_std::Error;
-
-use crate::{data::Cell, matrix::Dimensions};
-use avail_core::constants::kate::COMMITMENT_SIZE;
-
+#[cfg(feature = "std")]
+use poly_multiproof::traits::AsBytes;
+#[cfg(feature = "std")]
 use poly_multiproof::{
 	ark_poly::{EvaluationDomain as ArkEvaluationDomain, GeneralEvaluationDomain},
 	m1_blst::{Bls12_381, Fr, M1NoPrecomp, Proof as ArkProof},
 	traits::KZGProof,
 };
-
+#[cfg(feature = "std")]
 type ArkScalar = poly_multiproof::m1_blst::Fr;
+#[cfg(feature = "std")]
 type ArkCommitment = poly_multiproof::Commitment<Bls12_381>;
-use poly_multiproof::traits::AsBytes;
 
 #[derive(Error, Debug)]
 pub enum Error {

--- a/kate/recovery/src/proof.rs
+++ b/kate/recovery/src/proof.rs
@@ -45,6 +45,12 @@ impl From<dusk_bytes::Error> for Error {
 }
 
 /// Verifies proof for given cell
+///
+/// # Deprecated
+/// This function is deprecated. Use [`verify_v2`] instead, which uses arkworks primitives.
+#[deprecated(
+	note = "This function is deprecated. Use `verify_v2` instead, which uses arkworks primitives."
+)]
 #[cfg(feature = "std")]
 pub fn verify(
 	public_parameters: &PublicParameters,

--- a/kate/src/com.rs
+++ b/kate/src/com.rs
@@ -501,8 +501,8 @@ pub fn par_build_commitments<const CHUNK_SIZE: usize, M: Metrics>(
 	rng_seed: Seed,
 	metrics: &M,
 ) -> Result<(XtsLayout, Vec<u8>, BlockDimensions, DMatrix<BlsScalar>), Error> {
-	use avail_core::from_substrate;
 	use crate::couscous;
+	use avail_core::from_substrate;
 
 	let start = Instant::now();
 

--- a/kate/src/com.rs
+++ b/kate/src/com.rs
@@ -47,7 +47,7 @@ use crate::{
 	padded_len_of_pad_iec_9797_1, BlockDimensions, Seed, TryFromBlockDimensionsError, LOG_TARGET,
 };
 #[cfg(feature = "std")]
-use kate_recovery::{matrix::Dimensions, testnet};
+use kate_recovery::matrix::Dimensions;
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Constructor, Clone, Copy, PartialEq, Eq, Debug)]
@@ -502,6 +502,7 @@ pub fn par_build_commitments<const CHUNK_SIZE: usize, M: Metrics>(
 	metrics: &M,
 ) -> Result<(XtsLayout, Vec<u8>, BlockDimensions, DMatrix<BlsScalar>), Error> {
 	use avail_core::from_substrate;
+	use crate::couscous;
 
 	let start = Instant::now();
 
@@ -521,8 +522,8 @@ pub fn par_build_commitments<const CHUNK_SIZE: usize, M: Metrics>(
 
 	metrics.preparation_block_time(start.elapsed());
 
-	let public_params = testnet::public_params(block_dims_cols);
-
+	// let public_params = testnet::public_params(block_dims_cols);
+	let public_params = couscous::public_params();
 	if log::log_enabled!(target: LOG_TARGET, log::Level::Debug) {
 		let raw_pp = public_params.to_raw_var_bytes();
 		let hash_pp = hex::encode(from_substrate::blake2_128(&raw_pp));
@@ -661,6 +662,7 @@ mod tests {
 	use super::*;
 	use crate::{
 		com::{pad_iec_9797_1, par_extend_data_matrix, BlockDimensions},
+		couscous,
 		metrics::IgnoreMetrics,
 		padded_len,
 	};
@@ -897,8 +899,10 @@ mod tests {
 			prop_assert_eq!(data[0].as_slice(), &xt.data);
 		}
 
-		let dims_cols = usize::try_from(dims.cols.0).unwrap();
-		let public_params = testnet::public_params(dims_cols);
+		// let dims_cols = usize::try_from(dims.cols.0).unwrap();
+		// let public_params = testnet::public_params(dims_cols);
+		let public_params = couscous::public_params();
+		let pmp_pp = couscous::multiproof_params();
 		for cell in random_cells(dims.cols, dims.rows, Percent::one() ) {
 			let row = usize::try_from(cell.row.0).unwrap();
 
@@ -911,7 +915,8 @@ mod tests {
 
 			let extended_dims = dims.try_into().unwrap();
 			let commitment = commitments::from_slice(&commitments).unwrap()[row];
-			let verification =  proof::verify(&public_params, extended_dims, &commitment,  &cell);
+			// let verification =  proof::verify(&public_params, extended_dims, &commitment,  &cell);
+			let verification =  proof::verify_v2(&pmp_pp, extended_dims, &commitment,  &cell);
 			prop_assert!(verification.is_ok());
 			prop_assert!(verification.unwrap());
 		}
@@ -926,8 +931,8 @@ mod tests {
 		let (layout, commitments, dims, matrix) = par_build_commitments::<TCHUNK_SIZE,_>(BlockLengthRows(64), BlockLengthColumns(16), xts, Seed::default(), &IgnoreMetrics{}).unwrap();
 
 		let index = DataLookup::from_id_and_len_iter(layout.into_iter()).unwrap();
-		let dims_cols = usize::try_from(dims.cols.0).unwrap();
-		let public_params = testnet::public_params(dims_cols);
+		// let dims_cols = usize::try_from(dims.cols.0).unwrap();
+		let public_params = couscous::public_params();
 		let extended_dims = dims.try_into().unwrap();
 		let commitments = commitments::from_slice(&commitments).unwrap();
 		for xt in xts {
@@ -946,8 +951,8 @@ mod tests {
 		let (layout, commitments, dims, matrix) = par_build_commitments::<TCHUNK_SIZE,_>(BlockLengthRows(64), BlockLengthColumns(16), xts, Seed::default(), &IgnoreMetrics{}).unwrap();
 
 		let index = DataLookup::from_id_and_len_iter(layout.into_iter()).unwrap();
-		let dims_cols = usize::try_from(dims.cols.0).unwrap();
-		let public_params = testnet::public_params(dims_cols);
+		// let dims_cols = usize::try_from(dims.cols.0).unwrap();
+		let public_params = couscous::public_params();
 		let extended_dims =  dims.try_into().unwrap();
 		let commitments = commitments::from_slice(&commitments).unwrap();
 		for xt in xts {
@@ -981,14 +986,14 @@ mod tests {
 			dimensions,
 			BlockDimensions::new(BlockLengthRows(1), BlockLengthColumns(4), TCHUNK).unwrap(),
 		);
-		let expected_commitments = hex!("911bc20a0709b046847fcc53eaa981d84738dd6a76beaf2495ec9efcb2da498dfed29a15b5724343ee54382a9a3102a3911bc20a0709b046847fcc53eaa981d84738dd6a76beaf2495ec9efcb2da498dfed29a15b5724343ee54382a9a3102a3");
+		let expected_commitments = hex!("a065fed16fecd58caa55232c60f91efe5e6ad351a3c9707ee279b35936abe74bcb992aaaf8b8b316649d6fe2f0a68802a065fed16fecd58caa55232c60f91efe5e6ad351a3c9707ee279b35936abe74bcb992aaaf8b8b316649d6fe2f0a68802");
 		assert_eq!(commitments, expected_commitments);
 	}
 
 	#[test]
 	// newapi wip
 	fn test_reconstruct_app_extrinsics_with_app_id() -> Result<(), Error> {
-		let app_id_1_data = br#""This is mocked test data. It will be formatted as a matrix of BLS scalar cells and then individual columns 
+		let app_id_1_data = br#""This is mocked test data. It will be formatted as a matrix of BLS scalar cells and then individual columns
 get erasure coded to ensure redundancy."#;
 
 		let app_id_2_data = br#""Let's see how this gets encoded and then reconstructed by sampling only some data."#;
@@ -1026,7 +1031,7 @@ get erasure coded to ensure redundancy."#;
 	#[test]
 	// newapi done
 	fn test_decode_app_extrinsics() -> Result<(), Error> {
-		let app_id_1_data = br#""This is mocked test data. It will be formatted as a matrix of BLS scalar cells and then individual columns 
+		let app_id_1_data = br#""This is mocked test data. It will be formatted as a matrix of BLS scalar cells and then individual columns
 get erasure coded to ensure redundancy."#;
 
 		let app_id_2_data = br#""Let's see how this gets encoded and then reconstructed by sampling only some data."#;
@@ -1074,7 +1079,7 @@ get erasure coded to ensure redundancy."#;
 	#[test]
 	// newapi done
 	fn test_extend_mock_data() -> Result<(), Error> {
-		let orig_data = br#"This is mocked test data. It will be formatted as a matrix of BLS scalar cells and then individual columns 
+		let orig_data = br#"This is mocked test data. It will be formatted as a matrix of BLS scalar cells and then individual columns
 get erasure coded to ensure redundancy.
 Let's see how this gets encoded and then reconstructed by sampling only some data."#;
 
@@ -1227,7 +1232,9 @@ Let's see how this gets encoded and then reconstructed by sampling only some dat
 		// There are two main cases that generate a zero degree polynomial. One is for data that is non-zero, but the same.
 		// The other is for all-zero data. They differ, as the former yields a polynomial with one coefficient, and latter generates zero coefficients.
 		let len = row_values.len();
-		let public_params = testnet::public_params(len);
+		// let public_params = testnet::public_params(len);
+		let public_params = couscous::public_params();
+		let pmp_pp = couscous::multiproof_params();
 		let (prover_key, _) = public_params.trim(len).map_err(Error::from).unwrap();
 		let row_eval_domain = EvaluationDomain::new(len).map_err(Error::from).unwrap();
 
@@ -1278,7 +1285,8 @@ Let's see how this gets encoded and then reconstructed by sampling only some dat
 				position: Position { row: 0, col },
 				content: proof.try_into().unwrap(),
 			};
-			let verification = proof::verify(&public_params, dims, &commitment, &cell);
+			// let verification = proof::verify(&public_params, dims, &commitment, &cell);
+			let verification = proof::verify_v2(&pmp_pp, dims, &commitment, &cell);
 			assert!(verification.is_ok());
 			assert!(verification.unwrap())
 		}

--- a/kate/src/couscous.rs
+++ b/kate/src/couscous.rs
@@ -1,0 +1,154 @@
+#![deny(clippy::arithmetic_side_effects)]
+
+use dusk_plonk::commitment_scheme::kzg10::PublicParameters;
+
+// TODO: load pp for both dusk & arkworks from same file
+// To be used for incentivised testnet
+use core::convert::TryInto;
+use poly_multiproof::ark_serialize::CanonicalDeserialize;
+use poly_multiproof::m1_blst;
+use poly_multiproof::m1_blst::{G1, G2};
+use sp_std::vec::Vec;
+
+/// Constructs public parameters from pre-generated points for degree upto 1024
+pub fn public_params() -> PublicParameters {
+	// We can also use the raw data to make deserilization faster at the cost of size of the data
+	let pp_bytes = include_bytes!("pp_1024.data");
+	PublicParameters::from_slice(pp_bytes).expect("Deserialization should work")
+}
+
+// Loads the pre-generated trusted g1 & g2 from the file
+fn load_trusted_g1_g2() -> (Vec<G1>, Vec<G2>) {
+	// for degree = 1024
+	let contents = include_str!("g1_g2_1024.txt");
+	let mut lines = contents.lines();
+	let g1_len: usize = lines.next().unwrap().parse().unwrap();
+	let g2_len: usize = lines.next().unwrap().parse().unwrap();
+
+	let g1_bytes: Vec<[u8; 48]> = lines
+		.by_ref()
+		.take(g1_len)
+		.map(|line| hex::decode(line).unwrap().try_into().unwrap())
+		.collect();
+
+	let g2_bytes: Vec<[u8; 96]> = lines
+		.take(g2_len)
+		.map(|line| hex::decode(line).unwrap().try_into().unwrap())
+		.collect();
+
+	let g1: Vec<G1> = g1_bytes
+		.iter()
+		.map(|bytes| G1::deserialize_compressed(&bytes[..]).unwrap())
+		.collect();
+
+	let g2: Vec<G2> = g2_bytes
+		.iter()
+		.map(|bytes| G2::deserialize_compressed(&bytes[..]).unwrap())
+		.collect();
+
+	(g1, g2)
+}
+
+///  Construct public parameters from pre-generated points for degree upto 1024
+pub fn multiproof_params() -> m1_blst::M1NoPrecomp {
+	let (g1, g2) = load_trusted_g1_g2();
+	m1_blst::M1NoPrecomp::new_from_powers(g1, g2)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::*;
+	use dusk_plonk::{
+		commitment_scheme::kzg10::proof::Proof,
+		fft::{EvaluationDomain as DPEvaluationDomain, Evaluations},
+	};
+	use kate_recovery::{data::Cell, matrix::Position};
+	use pmp::{
+		ark_poly::{
+			univariate::DensePolynomial, DenseUVPolynomial, EvaluationDomain,
+			GeneralEvaluationDomain,
+		},
+		traits::KZGProof,
+	};
+	use poly_multiproof::{
+		m1_blst::Fr,
+		traits::{AsBytes, Committer},
+	};
+	use rand::thread_rng;
+
+	#[test]
+	fn test_consistent_testnet_params() {
+		use dusk_bytes::Serializable;
+		use dusk_plonk::prelude::BlsScalar;
+
+		let pmp = multiproof_params();
+		let pmp2 = public_params();
+
+		let points = DensePolynomial::<Fr>::rand(1023, &mut thread_rng()).coeffs;
+		let points2: Vec<_> = points
+			.iter()
+			.map(|p| BlsScalar::from_bytes(&p.to_bytes().unwrap()).unwrap())
+			.collect();
+
+		let dp_ev = DPEvaluationDomain::new(1024).unwrap();
+		let dp_poly = Evaluations::from_vec_and_domain(points2.clone(), dp_ev).interpolate();
+		let dp_domain_pts = dp_ev.elements().collect::<Vec<_>>();
+		let pmp_ev = GeneralEvaluationDomain::<Fr>::new(1024).unwrap();
+		let pmp_poly = pmp_ev.ifft(&points);
+		let pmp_domain_pts = pmp_ev.elements().collect::<Vec<_>>();
+
+		let dp_commit = pmp2.commit_key().commit(&dp_poly).unwrap();
+		let pmp_commit = pmp.commit(&pmp_poly).unwrap();
+
+		assert_eq!(dp_commit.0.to_bytes(), pmp_commit.to_bytes().unwrap());
+
+		let proof = pmp
+			.open(
+				pmp.compute_witness_polynomial(pmp_poly, pmp_domain_pts[1])
+					.unwrap(),
+			)
+			.unwrap();
+
+		let proof2 = pmp2
+			.commit_key()
+			.commit(
+				&pmp2
+					.commit_key()
+					.compute_single_witness(&dp_poly, &dp_domain_pts[1]),
+			)
+			.unwrap();
+
+		assert_eq!(proof.to_bytes().unwrap(), proof2.to_bytes());
+
+		let verify1 = pmp
+			.verify(&pmp_commit, pmp_domain_pts[1], points[1], &proof)
+			.unwrap();
+
+		let dp_proof_obj = Proof {
+			commitment_to_witness: proof2,
+			evaluated_point: points2[1],
+			commitment_to_polynomial: dp_commit,
+		};
+		assert!(pmp2.opening_key().check(dp_domain_pts[1], dp_proof_obj));
+
+		let mut content = [0u8; 80];
+		content[..48].copy_from_slice(&proof2.to_bytes());
+		content[48..].copy_from_slice(&points2[1].to_bytes());
+		let verify2 = kate_recovery::proof::verify(
+			&pmp2,
+			Dimensions::new(1, 1024).unwrap(),
+			&dp_commit.0.to_bytes(),
+			&Cell {
+				content,
+				position: Position { row: 0, col: 1 },
+			},
+		)
+		.unwrap();
+
+		assert!(verify1);
+		assert!(verify2);
+	}
+}
+
+// vim: set noet nowrap

--- a/kate/src/lib.rs
+++ b/kate/src/lib.rs
@@ -63,7 +63,7 @@ pub mod testnet {
 	static SRS_DATA: Lazy<Mutex<HashMap<u32, PublicParameters>>> =
 		Lazy::new(|| Mutex::new(HashMap::new()));
 
-	/// constructs public parameters for a given degree  
+	/// constructs public parameters for a given degree
 	pub fn public_params(max_degree: BlockLengthColumns) -> PublicParameters {
 		let max_degree: u32 = max_degree.into();
 		let mut srs_data_locked = SRS_DATA.lock().unwrap();

--- a/kate/src/lib.rs
+++ b/kate/src/lib.rs
@@ -6,10 +6,10 @@ use core::{
 	convert::TryInto,
 	num::{NonZeroU32, TryFromIntError},
 };
-use sp_std::vec::Vec;
 pub use dusk_plonk::{commitment_scheme::kzg10::PublicParameters, prelude::BlsScalar};
 use kate_recovery::matrix::Dimensions;
 use sp_arithmetic::traits::SaturatedConversion;
+use sp_std::vec::Vec;
 use static_assertions::const_assert_ne;
 use thiserror_no_std::Error;
 

--- a/kate/src/lib.rs
+++ b/kate/src/lib.rs
@@ -1,26 +1,35 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![deny(clippy::arithmetic_side_effects)]
 
+#[cfg(feature = "std")]
+pub mod com;
+#[cfg(feature = "std")]
+pub mod gridgen;
+#[cfg(feature = "std")]
+pub mod testnet;
+
+pub mod couscous;
+pub mod metrics;
+
+// Exporting Dust Plonk, Dusk Bytes and poly_multiproof as pmp
+#[cfg(feature = "std")]
+pub use dusk_bytes;
+pub use dusk_plonk::{self, commitment_scheme::kzg10::PublicParameters, prelude::BlsScalar};
+pub use poly_multiproof as pmp;
+
 use avail_core::{constants::kate::DATA_CHUNK_SIZE, BlockLengthColumns, BlockLengthRows};
 use core::{
 	convert::TryInto,
 	num::{NonZeroU32, TryFromIntError},
 };
-pub use dusk_plonk::{commitment_scheme::kzg10::PublicParameters, prelude::BlsScalar};
 use kate_recovery::matrix::Dimensions;
 use sp_arithmetic::traits::SaturatedConversion;
-use sp_std::vec::Vec;
 use static_assertions::const_assert_ne;
 use thiserror_no_std::Error;
 
 pub const LOG_TARGET: &str = "kate";
 pub const U32_USIZE_ERR: &str = "`u32` cast to `usize` overflows, unsupported platform";
-
 pub type Seed = [u8; 32];
-
-#[cfg(feature = "std")]
-pub use dusk_bytes::Serializable;
-pub use poly_multiproof as pmp;
 
 pub mod config {
 	use super::{BlockLengthColumns, BlockLengthRows};
@@ -44,308 +53,6 @@ pub mod config {
 		BlockLengthColumns(256)
 	};
 	pub const MAXIMUM_BLOCK_SIZE: bool = cfg!(feature = "maximum-block-size");
-}
-
-/// TODO
-///  - Dedup this from `kate-recovery` once that library support `no-std`.
-#[cfg(feature = "std")]
-pub mod testnet {
-	use super::*;
-	use hex_literal::hex;
-	use once_cell::sync::Lazy;
-	use poly_multiproof::ark_ff::{BigInt, Fp};
-	use poly_multiproof::ark_serialize::CanonicalDeserialize;
-	use poly_multiproof::m1_blst;
-	use poly_multiproof::m1_blst::{Fr, G1, G2};
-	use rand_chacha::{rand_core::SeedableRng, ChaChaRng};
-	use std::{collections::HashMap, sync::Mutex};
-
-	static SRS_DATA: Lazy<Mutex<HashMap<u32, PublicParameters>>> =
-		Lazy::new(|| Mutex::new(HashMap::new()));
-
-	/// constructs public parameters for a given degree
-	pub fn public_params(max_degree: BlockLengthColumns) -> PublicParameters {
-		let max_degree: u32 = max_degree.into();
-		let mut srs_data_locked = SRS_DATA.lock().unwrap();
-		srs_data_locked
-			.entry(max_degree)
-			.or_insert_with(|| {
-				let mut rng = ChaChaRng::seed_from_u64(42);
-				let max_degree = usize::try_from(max_degree).unwrap();
-				PublicParameters::setup(max_degree, &mut rng).unwrap()
-			})
-			.clone()
-	}
-
-	const SEC_LIMBS: [u64; 4] = [
-		16526363067508752668,
-		17870878028964021343,
-		15693365399533249662,
-		1020900941429372507,
-	];
-	const G1_BYTES: [u8; 48] = hex!("a45f754a9e94cccbb2cbe9d7c441b8b527026ef05e2a3aff4aa4bb1c57df3767fb669cc4c7639bd37e683653bdc50b5a");
-	const G2_BYTES: [u8; 96] = hex!("b845ac5e7b4ec8541d012660276772e001c1e0475e60971884481d43fcbd44de2a02e9862dbf9f536c211814f6cc5448100bcda5dc707854af8e3829750d1fb18b127286aaa4fc959e732e2128a8a315f2f8f419bf5774fe043af46fbbeb4b27");
-
-	pub fn multiproof_params(max_degree: usize, max_pts: usize) -> m1_blst::M1NoPrecomp {
-		let x: Fr = Fp(BigInt(SEC_LIMBS), core::marker::PhantomData);
-
-		let g1 = G1::deserialize_compressed(&G1_BYTES[..]).unwrap();
-		let g2 = G2::deserialize_compressed(&G2_BYTES[..]).unwrap();
-
-		m1_blst::M1NoPrecomp::new_from_scalar(x, g1, g2, max_degree.saturating_add(1), max_pts)
-	}
-
-	#[cfg(test)]
-	mod tests {
-		use core::marker::PhantomData;
-
-		use super::*;
-		use dusk_bytes::Serializable;
-		use dusk_plonk::{
-			fft::{EvaluationDomain as PlonkED, Evaluations as PlonkEV},
-			prelude::BlsScalar,
-		};
-		use poly_multiproof::{
-			ark_ff::{BigInt, Fp},
-			ark_poly::{EvaluationDomain, GeneralEvaluationDomain},
-			ark_serialize::{CanonicalDeserialize, CanonicalSerialize},
-			m1_blst::Fr,
-			traits::Committer,
-		};
-		use rand::thread_rng;
-
-		use crate::testnet;
-		#[test]
-		fn test_consistent_testnet_params() {
-			let x: Fr = Fp(BigInt(SEC_LIMBS), core::marker::PhantomData);
-			let mut out = [0u8; 32];
-			x.serialize_compressed(&mut out[..]).unwrap();
-			const SEC_BYTES: [u8; 32] =
-				hex!("7848b5d711bc9883996317a3f9c90269d56771005d540a19184939c9e8d0db2a");
-			assert_eq!(SEC_BYTES, out);
-
-			let g1 = G1::deserialize_compressed(&G1_BYTES[..]).unwrap();
-			let g2 = G2::deserialize_compressed(&G2_BYTES[..]).unwrap();
-
-			let pmp = poly_multiproof::m1_blst::M1NoPrecomp::new_from_scalar(x, g1, g2, 1024, 256);
-
-			let dp_evals = (0..30)
-				.map(|_| BlsScalar::random(&mut thread_rng()))
-				.collect::<Vec<_>>();
-
-			let pmp_evals = dp_evals
-				.iter()
-				.map(|i| Fp(BigInt(i.0), PhantomData))
-				.collect::<Vec<Fr>>();
-
-			let dp_poly =
-				PlonkEV::from_vec_and_domain(dp_evals, PlonkED::new(1024).unwrap()).interpolate();
-			let pmp_ev = GeneralEvaluationDomain::<Fr>::new(1024).unwrap();
-			let pmp_poly = pmp_ev.ifft(&pmp_evals);
-
-			let pubs = testnet::public_params(BlockLengthColumns(1024));
-
-			let dp_commit = pubs.commit_key().commit(&dp_poly).unwrap().0.to_bytes();
-			let mut pmp_commit = [0u8; 48];
-			pmp.commit(pmp_poly)
-				.unwrap()
-				.0
-				.serialize_compressed(&mut pmp_commit[..])
-				.unwrap();
-
-			assert_eq!(dp_commit, pmp_commit);
-		}
-	}
-}
-
-// TODO: load pp for both dusk & arkworks from same file
-// To be used for incentivised testnet
-pub mod couscous {
-	use super::*;
-	use poly_multiproof::ark_serialize::CanonicalDeserialize;
-	use poly_multiproof::m1_blst;
-	use poly_multiproof::m1_blst::{G1, G2};
-
-	/// Constructs public parameters from pre-generated points for degree upto 1024
-	pub fn public_params() -> PublicParameters {
-		// We can also use the raw data to make deserilization faster at the cost of size of the data
-		let pp_bytes = include_bytes!("pp_1024.data");
-		PublicParameters::from_slice(pp_bytes).expect("Deserialization should work")
-	}
-
-	// Loads the pre-generated trusted g1 & g2 from the file
-	fn load_trusted_g1_g2() -> (Vec<G1>, Vec<G2>) {
-		// for degree = 1024
-		let contents = include_str!("g1_g2_1024.txt");
-		let mut lines = contents.lines();
-		let g1_len: usize = lines.next().unwrap().parse().unwrap();
-		let g2_len: usize = lines.next().unwrap().parse().unwrap();
-
-		let g1_bytes: Vec<[u8; 48]> = lines
-			.by_ref()
-			.take(g1_len)
-			.map(|line| hex::decode(line).unwrap().try_into().unwrap())
-			.collect();
-
-		let g2_bytes: Vec<[u8; 96]> = lines
-			.take(g2_len)
-			.map(|line| hex::decode(line).unwrap().try_into().unwrap())
-			.collect();
-
-		let g1: Vec<G1> = g1_bytes
-			.iter()
-			.map(|bytes| G1::deserialize_compressed(&bytes[..]).unwrap())
-			.collect();
-
-		let g2: Vec<G2> = g2_bytes
-			.iter()
-			.map(|bytes| G2::deserialize_compressed(&bytes[..]).unwrap())
-			.collect();
-
-		(g1, g2)
-	}
-
-	///  Construct public parameters from pre-generated points for degree upto 1024
-	pub fn multiproof_params() -> m1_blst::M1NoPrecomp {
-		let (g1, g2) = load_trusted_g1_g2();
-		m1_blst::M1NoPrecomp::new_from_powers(g1, g2)
-	}
-
-	#[cfg(test)]
-	mod tests {
-		use super::*;
-		use dusk_plonk::{
-			commitment_scheme::kzg10::proof::Proof,
-			fft::{EvaluationDomain as DPEvaluationDomain, Evaluations},
-		};
-		use kate_recovery::{data::Cell, matrix::Position};
-		use pmp::{
-			ark_poly::{
-				univariate::DensePolynomial, DenseUVPolynomial, EvaluationDomain,
-				GeneralEvaluationDomain,
-			},
-			traits::KZGProof,
-		};
-		use poly_multiproof::{
-			m1_blst::Fr,
-			traits::{AsBytes, Committer},
-		};
-		use rand::thread_rng;
-
-		#[test]
-		fn test_consistent_testnet_params() {
-			let pmp = couscous::multiproof_params();
-			let pmp2 = couscous::public_params();
-
-			let points = DensePolynomial::<Fr>::rand(1023, &mut thread_rng()).coeffs;
-			let points2: Vec<_> = points
-				.iter()
-				.map(|p| BlsScalar::from_bytes(&p.to_bytes().unwrap()).unwrap())
-				.collect();
-
-			let dp_ev = DPEvaluationDomain::new(1024).unwrap();
-			let dp_poly = Evaluations::from_vec_and_domain(points2.clone(), dp_ev).interpolate();
-			let dp_domain_pts = dp_ev.elements().collect::<Vec<_>>();
-			let pmp_ev = GeneralEvaluationDomain::<Fr>::new(1024).unwrap();
-			let pmp_poly = pmp_ev.ifft(&points);
-			let pmp_domain_pts = pmp_ev.elements().collect::<Vec<_>>();
-
-			let dp_commit = pmp2.commit_key().commit(&dp_poly).unwrap();
-			let pmp_commit = pmp.commit(&pmp_poly).unwrap();
-
-			assert_eq!(dp_commit.0.to_bytes(), pmp_commit.to_bytes().unwrap());
-
-			let proof = pmp
-				.open(
-					pmp.compute_witness_polynomial(pmp_poly, pmp_domain_pts[1])
-						.unwrap(),
-				)
-				.unwrap();
-
-			let proof2 = pmp2
-				.commit_key()
-				.commit(
-					&pmp2
-						.commit_key()
-						.compute_single_witness(&dp_poly, &dp_domain_pts[1]),
-				)
-				.unwrap();
-
-			assert_eq!(proof.to_bytes().unwrap(), proof2.to_bytes());
-
-			let verify1 = pmp
-				.verify(&pmp_commit, pmp_domain_pts[1], points[1], &proof)
-				.unwrap();
-
-			let dp_proof_obj = Proof {
-				commitment_to_witness: proof2,
-				evaluated_point: points2[1],
-				commitment_to_polynomial: dp_commit,
-			};
-			assert!(pmp2.opening_key().check(dp_domain_pts[1], dp_proof_obj));
-
-			let mut content = [0u8; 80];
-			content[..48].copy_from_slice(&proof2.to_bytes());
-			content[48..].copy_from_slice(&points2[1].to_bytes());
-			let verify2 = kate_recovery::proof::verify(
-				&pmp2,
-				Dimensions::new(1, 1024).unwrap(),
-				&dp_commit.0.to_bytes(),
-				&Cell {
-					content,
-					position: Position { row: 0, col: 1 },
-				},
-			)
-			.unwrap();
-
-			assert!(verify1);
-			assert!(verify2);
-		}
-	}
-}
-
-pub mod metrics;
-
-#[cfg(feature = "std")]
-pub mod com;
-
-#[cfg(feature = "std")]
-pub mod gridgen;
-
-/// Precalculate the g1_len of padding IEC 9797 1.
-///
-/// # NOTE
-/// There is a unit test to ensure this formula match with the current
-/// IEC 9797 1 algorithm we implemented. See `fn pad_iec_9797_1`
-#[inline]
-#[allow(clippy::arithmetic_side_effects)]
-fn padded_len_of_pad_iec_9797_1(len: u32) -> u32 {
-	let len_plus_one = len.saturating_add(1);
-	let offset = (DATA_CHUNK_SIZE - (len_plus_one as usize % DATA_CHUNK_SIZE)) % DATA_CHUNK_SIZE;
-	let offset: u32 = offset.saturated_into();
-
-	len_plus_one.saturating_add(offset)
-}
-
-/// Calculates the padded len based of initial `len`.
-#[allow(clippy::arithmetic_side_effects)]
-pub fn padded_len(len: u32, chunk_size: NonZeroU32) -> u32 {
-	let iec_9797_1_len = padded_len_of_pad_iec_9797_1(len);
-
-	const_assert_ne!(DATA_CHUNK_SIZE, 0);
-	debug_assert!(
-		chunk_size.get() >= DATA_CHUNK_SIZE as u32,
-		"`BlockLength.chunk_size` is valid by design .qed"
-	);
-	let diff_per_chunk = chunk_size.get() - DATA_CHUNK_SIZE as u32;
-	let pad_to_chunk_extra = if diff_per_chunk != 0 {
-		let chunks_count = iec_9797_1_len / DATA_CHUNK_SIZE as u32;
-		chunks_count * diff_per_chunk
-	} else {
-		0
-	};
-
-	iec_9797_1_len + pad_to_chunk_extra
 }
 
 #[cfg_attr(feature = "std", derive(Debug))]
@@ -403,6 +110,42 @@ impl TryInto<Dimensions> for BlockDimensions {
 	fn try_into(self) -> Result<Dimensions, Self::Error> {
 		Dimensions::new_from(self.rows.0, self.cols.0).ok_or(Self::Error::InvalidDimensions)
 	}
+}
+
+/// Precalculate the g1_len of padding IEC 9797 1.
+///
+/// # NOTE
+/// There is a unit test to ensure this formula match with the current
+/// IEC 9797 1 algorithm we implemented. See `fn pad_iec_9797_1`
+#[inline]
+#[allow(clippy::arithmetic_side_effects)]
+fn padded_len_of_pad_iec_9797_1(len: u32) -> u32 {
+	let len_plus_one = len.saturating_add(1);
+	let offset = (DATA_CHUNK_SIZE - (len_plus_one as usize % DATA_CHUNK_SIZE)) % DATA_CHUNK_SIZE;
+	let offset: u32 = offset.saturated_into();
+
+	len_plus_one.saturating_add(offset)
+}
+
+/// Calculates the padded len based of initial `len`.
+#[allow(clippy::arithmetic_side_effects)]
+pub fn padded_len(len: u32, chunk_size: NonZeroU32) -> u32 {
+	let iec_9797_1_len = padded_len_of_pad_iec_9797_1(len);
+
+	const_assert_ne!(DATA_CHUNK_SIZE, 0);
+	debug_assert!(
+		chunk_size.get() >= DATA_CHUNK_SIZE as u32,
+		"`BlockLength.chunk_size` is valid by design .qed"
+	);
+	let diff_per_chunk = chunk_size.get() - DATA_CHUNK_SIZE as u32;
+	let pad_to_chunk_extra = if diff_per_chunk != 0 {
+		let chunks_count = iec_9797_1_len / DATA_CHUNK_SIZE as u32;
+		chunks_count * diff_per_chunk
+	} else {
+		0
+	};
+
+	iec_9797_1_len + pad_to_chunk_extra
 }
 
 // vim: set noet nowrap

--- a/kate/src/lib.rs
+++ b/kate/src/lib.rs
@@ -6,7 +6,7 @@ use core::{
 	convert::TryInto,
 	num::{NonZeroU32, TryFromIntError},
 };
-#[cfg(feature = "std")]
+use sp_std::vec::Vec;
 pub use dusk_plonk::{commitment_scheme::kzg10::PublicParameters, prelude::BlsScalar};
 use kate_recovery::matrix::Dimensions;
 use sp_arithmetic::traits::SaturatedConversion;
@@ -20,7 +20,6 @@ pub type Seed = [u8; 32];
 
 #[cfg(feature = "std")]
 pub use dusk_bytes::Serializable;
-#[cfg(feature = "std")]
 pub use poly_multiproof as pmp;
 
 pub mod config {
@@ -161,7 +160,6 @@ pub mod testnet {
 
 // TODO: load pp for both dusk & arkworks from same file
 // To be used for incentivised testnet
-#[cfg(feature = "std")]
 pub mod couscous {
 	use super::*;
 	use poly_multiproof::ark_serialize::CanonicalDeserialize;

--- a/kate/src/testnet.rs
+++ b/kate/src/testnet.rs
@@ -1,0 +1,111 @@
+#![deny(clippy::arithmetic_side_effects)]
+
+/// TODO
+///  - Dedup this from `kate-recovery` once that library support `no-std`.
+use avail_core::BlockLengthColumns;
+use dusk_plonk::commitment_scheme::kzg10::PublicParameters;
+use hex_literal::hex;
+use once_cell::sync::Lazy;
+use poly_multiproof::ark_ff::{BigInt, Fp};
+use poly_multiproof::ark_serialize::CanonicalDeserialize;
+use poly_multiproof::m1_blst;
+use poly_multiproof::m1_blst::{Fr, G1, G2};
+use rand_chacha::{rand_core::SeedableRng, ChaChaRng};
+use std::{collections::HashMap, sync::Mutex};
+
+static SRS_DATA: Lazy<Mutex<HashMap<u32, PublicParameters>>> =
+	Lazy::new(|| Mutex::new(HashMap::new()));
+
+/// constructs public parameters for a given degree
+pub fn public_params(max_degree: BlockLengthColumns) -> PublicParameters {
+	let max_degree: u32 = max_degree.into();
+	let mut srs_data_locked = SRS_DATA.lock().unwrap();
+	srs_data_locked
+		.entry(max_degree)
+		.or_insert_with(|| {
+			let mut rng = ChaChaRng::seed_from_u64(42);
+			let max_degree = usize::try_from(max_degree).unwrap();
+			PublicParameters::setup(max_degree, &mut rng).unwrap()
+		})
+		.clone()
+}
+
+const SEC_LIMBS: [u64; 4] = [
+	16526363067508752668,
+	17870878028964021343,
+	15693365399533249662,
+	1020900941429372507,
+];
+const G1_BYTES: [u8; 48] = hex!("a45f754a9e94cccbb2cbe9d7c441b8b527026ef05e2a3aff4aa4bb1c57df3767fb669cc4c7639bd37e683653bdc50b5a");
+const G2_BYTES: [u8; 96] = hex!("b845ac5e7b4ec8541d012660276772e001c1e0475e60971884481d43fcbd44de2a02e9862dbf9f536c211814f6cc5448100bcda5dc707854af8e3829750d1fb18b127286aaa4fc959e732e2128a8a315f2f8f419bf5774fe043af46fbbeb4b27");
+
+pub fn multiproof_params(max_degree: usize, max_pts: usize) -> m1_blst::M1NoPrecomp {
+	let x: Fr = Fp(BigInt(SEC_LIMBS), core::marker::PhantomData);
+
+	let g1 = G1::deserialize_compressed(&G1_BYTES[..]).unwrap();
+	let g2 = G2::deserialize_compressed(&G2_BYTES[..]).unwrap();
+
+	m1_blst::M1NoPrecomp::new_from_scalar(x, g1, g2, max_degree.saturating_add(1), max_pts)
+}
+
+#[cfg(test)]
+mod tests {
+	use core::marker::PhantomData;
+
+	use super::*;
+	use dusk_bytes::Serializable;
+	use dusk_plonk::{
+		fft::{EvaluationDomain as PlonkED, Evaluations as PlonkEV},
+		prelude::BlsScalar,
+	};
+	use poly_multiproof::{
+		ark_ff::{BigInt, Fp},
+		ark_poly::{EvaluationDomain, GeneralEvaluationDomain},
+		ark_serialize::{CanonicalDeserialize, CanonicalSerialize},
+		m1_blst::Fr,
+		traits::Committer,
+	};
+	use rand::thread_rng;
+
+	use crate::testnet;
+	#[test]
+	fn test_consistent_testnet_params() {
+		let x: Fr = Fp(BigInt(SEC_LIMBS), core::marker::PhantomData);
+		let mut out = [0u8; 32];
+		x.serialize_compressed(&mut out[..]).unwrap();
+		const SEC_BYTES: [u8; 32] =
+			hex!("7848b5d711bc9883996317a3f9c90269d56771005d540a19184939c9e8d0db2a");
+		assert_eq!(SEC_BYTES, out);
+
+		let g1 = G1::deserialize_compressed(&G1_BYTES[..]).unwrap();
+		let g2 = G2::deserialize_compressed(&G2_BYTES[..]).unwrap();
+
+		let pmp = poly_multiproof::m1_blst::M1NoPrecomp::new_from_scalar(x, g1, g2, 1024, 256);
+
+		let dp_evals = (0..30)
+			.map(|_| BlsScalar::random(&mut thread_rng()))
+			.collect::<Vec<_>>();
+
+		let pmp_evals = dp_evals
+			.iter()
+			.map(|i| Fp(BigInt(i.0), PhantomData))
+			.collect::<Vec<Fr>>();
+
+		let dp_poly =
+			PlonkEV::from_vec_and_domain(dp_evals, PlonkED::new(1024).unwrap()).interpolate();
+		let pmp_ev = GeneralEvaluationDomain::<Fr>::new(1024).unwrap();
+		let pmp_poly = pmp_ev.ifft(&pmp_evals);
+
+		let pubs = testnet::public_params(BlockLengthColumns(1024));
+
+		let dp_commit = pubs.commit_key().commit(&dp_poly).unwrap().0.to_bytes();
+		let mut pmp_commit = [0u8; 48];
+		pmp.commit(pmp_poly)
+			.unwrap()
+			.0
+			.serialize_compressed(&mut pmp_commit[..])
+			.unwrap();
+
+		assert_eq!(dp_commit, pmp_commit);
+	}
+}


### PR DESCRIPTION
Enhance the couscous module for compatibility with no_std environments and implement a new proof verification function `verify_v2` utilizing ark primitives. Updated tests accordingly and added a deprecation notice for the old `verify` function.