### PR TITLE
fix(header): remove unused variable Clippy warnings

### DIFF
--- a/core/src/header/mod.rs
+++ b/core/src/header/mod.rs
@@ -114,15 +114,14 @@ where
 	H::Output: TypeInfo,
 {
 	fn fmt(&self, f: &mut Formatter<'_>) -> sp_std::fmt::Result {
-		let parent_hash = self.parent_hash.as_ref();
-		let state_root = self.state_root.as_ref();
-		let extrinsics_root = self.extrinsics_root.as_ref();
-
 		f.debug_struct("Header")
-			.field("parent_hash", &HexDisplay(&parent_hash))
+			.field("parent_hash", &HexDisplay(self.parent_hash.as_ref()))
 			.field("number", &self.number)
-			.field("state_root", &HexDisplay(&state_root))
-			.field("extrinsics_root", &HexDisplay(&extrinsics_root))
+			.field("state_root", &HexDisplay(self.state_root.as_ref()))
+			.field(
+				"extrinsics_root",
+				&HexDisplay(self.extrinsics_root.as_ref()),
+			)
 			.field("digest", &self.digest)
 			.field("extension", &self.extension)
 			.finish()


### PR DESCRIPTION
This PR resolves Clippy warnings related to unused variables in `core/src/header/mod.rs`.

###  Problem
`cargo clippy --all --all-targets --all-features -- -D warnings` 

![Pasted Graphic 7](https://github.com/user-attachments/assets/a724ec25-0b0d-4a80-b26f-0e1dbe590a80)

###  Solution
Removed the temporary bindings and passed the expressions directly to `HexDisplay(...)`.

###  Result
After this fix, `cargo clippy --all --all-targets --all-features -- -D warnings` runs cleanly.

